### PR TITLE
Subject: Topology endpoint broken

### DIFF
--- a/webapp/runtime/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
+++ b/webapp/runtime/src/main/java/org/wildfly/swarm/topology/webapp/runtime/TopologySSEServlet.java
@@ -17,6 +17,8 @@ package org.wildfly.swarm.topology.webapp.runtime;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -158,7 +160,17 @@ public class TopologySSEServlet extends HttpServlet {
             } else {
                 while (listIter.hasNext()) {
                     Topology.Entry server = listIter.next();
-                    String endpoint = server.getAddress() + ":" + server.getPort();
+
+                    boolean invalidServerAddress = false;
+                    try {
+                        //noinspection ResultOfMethodCallIgnored
+                        InetAddress.getByName(server.getAddress());
+                    } catch (UnknownHostException e) {
+                        invalidServerAddress = true;
+                    }
+
+                    String endpoint = (!invalidServerAddress ? (server.getTags().contains("https") ? "https" : "http") + "://" : "")
+                            + server.getAddress() + ":" + server.getPort();
                     populateEndpointAndTagsJson(json, endpoint, server.getTags());
                     if (listIter.hasNext()) {
                         json.append(",");


### PR DESCRIPTION
Motivation:
SWARM-341. Endpoint provided by Topology, when no proxy being used, does not contain the scheme (http/https) which causes the browser to not be able to make the request

Modifications:
TopologySSEServlet modified to check whether a server address is a valid host/ip and to prepend the appropriate scheme if it is

Result:
Enables topology services to be correctly called when they're not proxied
